### PR TITLE
fix: remove print statements in except block

### DIFF
--- a/weaviate/client_base.py
+++ b/weaviate/client_base.py
@@ -168,7 +168,6 @@ class _WeaviateClientBase(_WeaviateClientInit):
                 return True
             return False
         except Exception as e:
-            print(e)
             return False
 
     async def is_ready(self) -> bool:
@@ -178,7 +177,6 @@ class _WeaviateClientBase(_WeaviateClientInit):
                 return True
             return False
         except Exception as e:
-            print(e)
             return False
 
     async def graphql_raw_query(self, gql_query: str) -> _RawGQLReturn:


### PR DESCRIPTION
The print statement results in unwanted console output. It's not controllable. Since in the client there is no logger, no printing is better than `print(e)`.
In projects using this client such statements are rather annoying.